### PR TITLE
Add selfClose option for void tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,18 @@ module.exports = options => {
 	options = Object.assign({
 		name: 'div',
 		attributes: {},
-		value: ''
+		value: '',
+		selfClose: false
 	}, options);
 
-	let ret = `<${options.name}${stringifyAttributes(options.attributes)}>`;
+	let ret = `<${options.name}${stringifyAttributes(options.attributes)}`;
 
 	if (!voidHtmlTags.has(options.name)) {
 		ret += `${options.value}</${options.name}>`;
+	} else if (options.selfClose) {
+		ret += '/>';
+	} else {
+		ret += '>';
 	}
 
 	return ret;

--- a/readme.md
+++ b/readme.md
@@ -55,9 +55,11 @@ HTML tag attributes.
 
 HTML tag value.
 
-##### selfClose *(Boolean)*
+##### selfClose
 
-Specify to selfClose void tags or not. *default: false*
+Type: `boolean`<br>
+Default: `false`
+Specify to selfClose void tags or not.
 
 
 

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,11 @@ HTML tag attributes.
 
 HTML tag value.
 
+##### selfClose *(Boolean)*
+
+Specify to selfClose void tags or not. *default: false*
+
+
 
 ## Related
 


### PR DESCRIPTION
for XHTML codes we should generated self closed tags with / at the end like <br />, but because of HTML5 we do <br>. 
Then an option to control that would be useful.