### PR TITLE
Replace `value` option with `html` and `text`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const stringifyAttributes = require('stringify-attributes');
 const htmlTags = require('html-tags/void');
+const escapeGoat = require('escape-goat');
 
 const voidHtmlTags = new Set(htmlTags);
 
@@ -8,13 +9,14 @@ module.exports = options => {
 	options = Object.assign({
 		name: 'div',
 		attributes: {},
-		value: ''
+		html: ''
 	}, options);
 
+	const content = options.text ? escapeGoat.escape(options.text) : options.html;
 	let ret = `<${options.name}${stringifyAttributes(options.attributes)}>`;
 
 	if (!voidHtmlTags.has(options.name)) {
-		ret += `${options.value}</${options.name}>`;
+		ret += `${content}</${options.name}>`;
 	}
 
 	return ret;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "tag"
   ],
   "dependencies": {
+    "escape-goat": "^1.3.0",
     "html-tags": "^2.0.0",
     "stringify-attributes": "^1.0.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,12 @@ createHtmlElement({
 		number: 1,
 		multiple: ['a', 'b']
 	},
-	value: '🦄'
+	html: '🦄'
 });
 //=> '<h1 class="unicorn" rainbow number="1" multiple="a b">🦄</h1>'
+
+createHtmlElement({text: 'Hello <em>World</em>'});
+//=> '<div>Hello &lt;em&gt;World&lt;/em&gt;</div>'
 ```
 
 
@@ -51,9 +54,13 @@ Type: `Object`
 
 HTML tag attributes.
 
-##### value
+##### html
 
-HTML tag value.
+HTML tag value in unescaped HTML. This option is mutually exclusive with the `text` option.
+
+##### text
+
+HTML tag value in escaped HTML. This option is mutually exclusive with the `html` option.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('creates element', t => {
 				number: 1,
 				multiple: ['a', 'b']
 			},
-			value: '🦄'
+			html: '🦄'
 		}),
 		'<h1 class="unicorn" rainbow number="1" multiple="a b">🦄</h1>'
 	);
@@ -30,7 +30,7 @@ test('creates void element', t => {
 			attributes: {
 				foo: 'bar'
 			},
-			value: 'noop'
+			html: 'noop'
 		}),
 		'<img foo="bar">'
 	);
@@ -46,5 +46,12 @@ test('supports boolean and non-string attribute values', t => {
 			}
 		}),
 		'<div foo one="1"></div>'
+	);
+});
+
+test('escapes text content', t => {
+	t.is(
+		m({text: '🦄 & 🐐'}),
+		'<div>🦄 &amp; 🐐</div>'
 	);
 });


### PR DESCRIPTION
I guess these has to be mutually exclusive from each other. Maybe it should error if both are defined?

Fixes #2.